### PR TITLE
Fix/adoption kostenlos und balancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+**[DE]**
+- Der Preis für die Adoption eines Waisenkindes wurde etwas erhöht und wird nun korrekt vom Vermögen des Spielers abgezogen
+
 ## 1.3.0
 
 _24.12.2020_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog Conspiratio.Lib
 
-## Unreleased
+## 2.0.0
+
+_23.12.2021_
 
 **[DE]**
-- Der Preis für die Adoption eines Waisenkindes wurde etwas erhöht und wird nun korrekt vom Vermögen des Spielers abgezogen
+- Der Preis für die Adoption eines Waisenkindes wurde etwas erhöht und wird nun korrekt vom Vermögen des Spielers abgezogen. Zusätzlich kostet eine Adoption nun Ansehen (Balancing).
+- Chance reduziert, von KI-Gegnern auf den Einstellungen niedrig und mittel angeklagt zu werden
+- Höhe der Geldstrafe vor Gericht reduziert
+- Wenn ein Spieler entfernt wird (egal ob durch Tod, Aufgabe oder manuelles Hinauswerfen):
+  - Dann werden nun seine Stützpunkte an zufällige KI-Spieler verteilt
+  - Dann behalten nachrückende Spieler nun ihre Stützpunkte, Beziehungen zu den KI-Spielern und Amtsinformationen im jeweiligen Gebiet
+- Das Minimum für maximale Anwesen (Finanzgesetz) wurde von 1 auf 4 erhöht
 
 ## 1.3.0
 

--- a/Conspiratio.Lib/Conspiratio.Lib.csproj
+++ b/Conspiratio.Lib/Conspiratio.Lib.csproj
@@ -222,6 +222,8 @@
     <PostBuildEvent>if $(ConfigurationName) == Debug (
 cd "$(ProjectDir)"
 nuget pack -Properties Configuration=Debug
-)</PostBuildEvent>
+)
+rem Falls es hier einen Fehler gibt siehe: https://github.com/NuGet/Home/issues/9954
+rem Nuget.exe muss ab 5.7 offenbar explizit zugelassen werden (Dateieigenschaften)</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Conspiratio.Lib/Gameplay/Justiz/StrafeGeldstrafe.cs
+++ b/Conspiratio.Lib/Gameplay/Justiz/StrafeGeldstrafe.cs
@@ -25,9 +25,9 @@ namespace Conspiratio.Lib.Gameplay.Justiz
             double faktor = 2000;
             
             if (jahresMultiplikator < 10)
-                faktor = 200;
+                faktor = 180;
             else if (jahresMultiplikator < 15)
-                faktor = 1000;
+                faktor = 800;
 
             deliktMultiplikator = (Convert.ToDouble(deliktpunkte) * deliktMultiplikator / 100d) + 1d;
 

--- a/Conspiratio.Lib/Gameplay/Kirche/Kirchgang.cs
+++ b/Conspiratio.Lib/Gameplay/Kirche/Kirchgang.cs
@@ -79,7 +79,8 @@ namespace Conspiratio.Lib.Gameplay.Kirche
 
             int preis = SW.Dynamisch.GetAktHum().ErmittlePreisWaisenkindAdoptieren(SW.Dynamisch.GetAktiverSpieler());
 
-            if (SW.UI.JaNeinFrage.ShowDialogText("Wollt Ihr ein Mündel für\n" + preis.ToStringGeld() + " aus dem \nkirchlichen Waisenhaus adoptieren?", "Ja", "Lieber nicht!") == DialogResult.Yes)
+            if (SW.UI.JaNeinFrage.ShowDialogText("Wollt Ihr ein Mündel für\n" + preis.ToStringGeld() + " aus dem \nkirchlichen Waisenhaus adoptieren? \nEuer Ansehen könnte darunter leiden ...", 
+                                                 "Ja", "Lieber nicht!") == DialogResult.Yes)
             {
                 SW.Dynamisch.GetAktHum().WaisenkindAdoptieren(preis);
             }

--- a/Conspiratio.Lib/Gameplay/Personen/HumSpieler.cs
+++ b/Conspiratio.Lib/Gameplay/Personen/HumSpieler.cs
@@ -746,6 +746,7 @@ namespace Conspiratio.Lib.Gameplay.Personen
             string name = SW.Statisch.GetKINameX(random);
 
             SetKindX(SW.Dynamisch.GetAktHum().GetEmptyKindSlot(), maennlich, name, 1);
+            SW.Dynamisch.PrivilegienAktualisieren();
 
             SW.Dynamisch.BelTextAnzeigen($"Dank Eurer großzügigen Spende \nkonntet Ihr das Kind {name} \naus dem Waisenhaus adoptieren. Euer Ansehen hat gelitten.");
         }

--- a/Conspiratio.Lib/Gameplay/Personen/HumSpieler.cs
+++ b/Conspiratio.Lib/Gameplay/Personen/HumSpieler.cs
@@ -732,6 +732,9 @@ namespace Conspiratio.Lib.Gameplay.Personen
             if (!SW.Dynamisch.CheckIfenoughGold(preis))
                 return;
 
+            SW.Dynamisch.GetAktHum().ErhoeheTaler(-preis);
+            SW.Dynamisch.GetHumWithID(SW.Dynamisch.GetAktiverSpieler()).ErhoehePermaAnsehen(-100);
+
             int random = SW.Statisch.Rnd.Next(0, 2);
             bool maennlich = random == 0;
 
@@ -744,20 +747,20 @@ namespace Conspiratio.Lib.Gameplay.Personen
 
             SetKindX(SW.Dynamisch.GetAktHum().GetEmptyKindSlot(), maennlich, name, 1);
 
-            SW.Dynamisch.BelTextAnzeigen($"Dank Eurer großzügigen Spende \nkonntet Ihr das Kind {name} \naus dem Waisenhaus adoptieren.");
+            SW.Dynamisch.BelTextAnzeigen($"Dank Eurer großzügigen Spende \nkonntet Ihr das Kind {name} \naus dem Waisenhaus adoptieren. Euer Ansehen hat gelitten.");
         }
         #endregion
 
         #region ErmittlePreisWaisenkindAdoptieren
         public int ErmittlePreisWaisenkindAdoptieren(int spielerID)
         {
-            int zufallswert = SW.Statisch.Rnd.Next(15, 25);
+            int prozentfaktor = 30;
             int gesamtvermoegen = GetGesamtVermoegen(spielerID);
 
-            if (gesamtvermoegen <= 0)
-                gesamtvermoegen = SW.Statisch.GetStartgold();  // falls kein Vermögen vorhanden ist (oder Schulden) wird vom Startkapital ausgegangen
+            if (gesamtvermoegen < SW.Statisch.GetStartgold())  // falls das Vermögen kleiner als das Startkapital ist, wird immer vom Startkapital ausgegangen
+                gesamtvermoegen = SW.Statisch.GetStartgold();  
 
-            return Convert.ToInt32((zufallswert * gesamtvermoegen) / 100);
+            return Convert.ToInt32(prozentfaktor * gesamtvermoegen / 100);
         }
         #endregion
     }

--- a/Conspiratio.Lib/Gameplay/Spielwelt/DynamischeSpieldaten.cs
+++ b/Conspiratio.Lib/Gameplay/Spielwelt/DynamischeSpieldaten.cs
@@ -1815,7 +1815,7 @@ namespace Conspiratio.Lib.Gameplay.Spielwelt
                     GetKIwithID(i).SetDeliktpunkte(Convert.ToInt32((GetKIwithID(i).GetDeliktpunkte() * 2) / 2));
                 }
 
-                #region Amtsentehungen
+                #region Amtsenthebungen
                 // Wenn sie zu einem Untergebenen eine schlechte Beziehung hat
                 int[] untergebene = GetUntergebene(i);
                 int u_len = 0;

--- a/Conspiratio.Lib/Gameplay/Spielwelt/StatischeSpieldaten.cs
+++ b/Conspiratio.Lib/Gameplay/Spielwelt/StatischeSpieldaten.cs
@@ -246,7 +246,7 @@ namespace Conspiratio.Lib.Gameplay.Spielwelt
             GesetzDefUntergrenze[1] = 0;
             GesetzDefObergrenze[1] = 1;
             //Hoechstzahl Anwesen
-            GesetzDefUntergrenze[2] = 1;
+            GesetzDefUntergrenze[2] = 4;
             GesetzDefObergrenze[2] = 14;
             //Maxmimale Taler
             GesetzDefUntergrenze[3] = 5;

--- a/Conspiratio.Lib/Properties/AssemblyInfo.cs
+++ b/Conspiratio.Lib/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Conspiratio")]
 [assembly: AssemblyProduct("Conspiratio")]
-[assembly: AssemblyCopyright("Copyright © 2011-2020")]
+[assembly: AssemblyCopyright("Copyright © 2011-2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
-[assembly: AssemblyVersion("1.3.0")]
-[assembly: AssemblyFileVersion("1.3.0")]
+[assembly: AssemblyVersion("1.3.1")]
+[assembly: AssemblyFileVersion("1.3.1")]

--- a/Conspiratio.Lib/Properties/AssemblyInfo.cs
+++ b/Conspiratio.Lib/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
-[assembly: AssemblyVersion("1.3.1")]
-[assembly: AssemblyFileVersion("1.3.1")]
+[assembly: AssemblyVersion("2.0.0")]
+[assembly: AssemblyFileVersion("2.0.0")]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Zur Planung und Steuerung der Entwicklung sollen Github Issues dienen.
 
 # Mitmachen
 
+Ihr wollt Euch an diesem Projekt beteiligen? Großartig! Tretet einfach mit uns über [Discord](https://discord.gg/dxkC5DPgRY) oder oldschool per <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;%6D%61%69%6C%40%63%6F%6E%73%70%69%72%61%74%69%6F%2E%6E%65%74">E-Mail</a> in Kontakt und wir klären die Details.  
+_Jegliche Hilfe ist willkommen._
+
 ## Git Workflow
 
 **Wichtig: Wir committen und pushen nie direkt in den master Branch!**  
@@ -86,7 +89,3 @@ Im Changelog nutzen wir folgende Gruppen zur Unterteilung der Änderungen:
 - Änderungen
 - Korrekturen
 - Balancing
-
-# Kontakt
-
-Über [Discord](https://discord.gg/dxkC5DPgRY) oder oldschool per <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;%6D%61%69%6C%40%63%6F%6E%73%70%69%72%61%74%69%6F%2E%6E%65%74">E-Mail</a>


### PR DESCRIPTION
- Der Preis für die Adoption eines Waisenkindes wurde etwas erhöht und wird nun korrekt vom Vermögen des Spielers abgezogen. Zusätzlich kostet eine Adoption nun Ansehen (Balancing).
- Chance reduziert, von KI-Gegnern auf den Einstellungen niedrig und mittel angeklagt zu werden
- Höhe der Geldstrafe vor Gericht reduziert
- Wenn ein Spieler entfernt wird (egal ob durch Tod, Aufgabe oder manuelles Hinauswerfen):
  - Dann werden nun seine Stützpunkte an zufällige KI-Spieler verteilt
  - Dann behalten nachrückende Spieler nun ihre Stützpunkte, Beziehungen zu den KI-Spielern und Amtsinformationen im jeweiligen Gebiet
- Das Minimum für maximale Anwesen (Finanzgesetz) wurde von 1 auf 4 erhöht

Bezieht sich auf Feedback von: https://conspiratio.net/forum/viewtopic.php?f=12&t=58