### PR TITLE
Fix/jurist aufsuchen rechtsklick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## 2.1.1
 
-_Unreleased_
+_30.10.2022_
 
 **[DE]**
 - Beim Privileg "Jurist aufsuchen" wird nun ein Rechtsklick im Dialog nicht mehr als "Ja" sondern als Abbruch gewertet
+- Die Vergabe von Titeln wurde neu balanciert und ist nun u.a. auch vom Wohnsitz sowie vom Besitz militärischer Stützpunkte abhängig, zusätzlich wurde die Talergrenze der höheren Titel herabgesetzt. Dafür wurde die Vergabelogik in die einzelnen Titel-Klassen ausgelagert sowie etwas aufgeräumt und optimiert.
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog Conspiratio.Lib
 
+## 2.1.1
+
+_Unreleased_
+
+**[DE]**
+- Beim Privileg "Jurist aufsuchen" wird nun ein Rechtsklick im Dialog nicht mehr als "Ja" sondern als Abbruch gewertet
+
 ## 2.1.0
 
 _23.10.2022_

--- a/Conspiratio.Lib/Gameplay/Personen/HumSpieler.cs
+++ b/Conspiratio.Lib/Gameplay/Personen/HumSpieler.cs
@@ -765,6 +765,50 @@ namespace Conspiratio.Lib.Gameplay.Personen
         }
         #endregion
 
+        #region BesitztSpielerFertigesHaus
+        /// <summary>
+        /// Gibt zurück, ob der aktuelle Spieler ein bestimmtes, fertiges Haus besitzt.
+        /// </summary>
+        /// <param name="hausname">Bezeichnung des gesuchten Hauses, z.B. Villa</param>
+        /// <returns>Besitzt der Spieler das fertige Haus (true) oder nicht (false)</returns>
+        public bool BesitztSpielerFertigesHaus(string hausname)
+        {
+            for (int i = 1; i < SW.Statisch.GetMaxStadtID(); i++)
+            {
+                var hausInStadt = _spielerHatHausVonStadtAnArraystelle[i];
+
+                if (hausInStadt.GetHausID() > 0 &&  // Existiert ein Haus?
+                    hausInStadt.GetRestlicheBauzeit() == 0 &&  // Ist es fertig gebaut?
+                    SW.Statisch.GetHaus(hausInStadt.GetHausID()).Name == hausname)  // Entspricht es dem gesuchten Haus?
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        #endregion
+
+        #region GetAnzahlStuetzpunkte
+        /// <summary>
+        /// Liefert die Anzahl der militärischen Stützpunkte, die der übergebene Spieler besitzt.
+        /// </summary>
+        /// <param name="spielerId">Id des Spielers</param>
+        /// <returns>Anzahl der Stützpunkte in seinem Besitz</returns>
+        public int GetAnzahlStuetzpunkte(int spielerId)
+        {
+            int anzahl = 0;
+
+            // Stützpunkte
+            for (int i = 0; i < SW.Dynamisch.GetStuetzpunkte().Length; i++)
+            {
+                if (SW.Dynamisch.GetStuetzpunkte()[i].Besitzer == spielerId)
+                    anzahl++;
+            }
+
+            return anzahl;
+        }
+        #endregion
 
         #region ToString (for debugging)
         /// <summary>

--- a/Conspiratio.Lib/Gameplay/Privilegien/PrivJurist.cs
+++ b/Conspiratio.Lib/Gameplay/Privilegien/PrivJurist.cs
@@ -16,7 +16,7 @@ namespace Conspiratio.Lib.Gameplay.Privilegien
             int preis = 1000;
 
             if (SW.UI.JaNeinFrage.ShowDialogText("Beim Jurist erhaltet Ihr Einblicke\nin Eure bisherigen Verbrechen und deren Bewertung.\n" +
-                                                $"Wollt Ihr diese Dienste für\n{preis.ToStringGeld()} in Anspruch nehmen?") == DialogResult.No)
+                                                $"Wollt Ihr diese Dienste für\n{preis.ToStringGeld()} in Anspruch nehmen?") != DialogResult.Yes)
             {
                 return;
             }

--- a/Conspiratio.Lib/Gameplay/Spielwelt/DynamischeSpieldaten.cs
+++ b/Conspiratio.Lib/Gameplay/Spielwelt/DynamischeSpieldaten.cs
@@ -12,6 +12,7 @@ using Conspiratio.Lib.Gameplay.Personen;
 using Conspiratio.Lib.Gameplay.Privilegien;
 using Conspiratio.Lib.Gameplay.Rohstoffe;
 using Conspiratio.Lib.Gameplay.Schreibstube;
+using Conspiratio.Lib.Gameplay.Titel;
 
 namespace Conspiratio.Lib.Gameplay.Spielwelt
 {
@@ -2502,6 +2503,29 @@ namespace Conspiratio.Lib.Gameplay.Spielwelt
             GetGerichtsverhandlungX(klageID).SetAll(richter1, richter2, richter3, stadtID, 0, GetAktiverSpieler(), klaegerID);
         }
         #endregion
+
+        #region VersuchTitelVerleihen
+        public void VersuchTitelVerleihen(int spielerId)
+        {
+            // Falls nicht schon einer diese Runde verliehen wird
+            if (GetHumWithID(spielerId).GetBekamTitelX() != 0)
+            {
+                return;
+            }
+
+            int aktuelleTitelId = GetHumWithID(spielerId).GetTitel();
+
+            foreach (Adelstitel titel in SW.Statisch.Titel)
+            {
+                if (titel.IstSpielerFuerTitelBerechtigt(this, spielerId) && titel.Id > aktuelleTitelId)
+                {
+                    GetHumWithID(spielerId).SetBekamTitelX(titel.Id);
+                    break;
+                }
+            }
+        }
+        #endregion
+
 
         // Private Methoden
         #region GetLeereWahlID

--- a/Conspiratio.Lib/Gameplay/Spielwelt/StatischeSpieldaten.cs
+++ b/Conspiratio.Lib/Gameplay/Spielwelt/StatischeSpieldaten.cs
@@ -113,7 +113,11 @@ namespace Conspiratio.Lib.Gameplay.Spielwelt
         private int MinTitelLandEbene;
         private int MinTitelReichsEbene;
 
-        private Adelstitel[] Tit;
+        /// <summary>
+        /// Alle vorhandenen Adelstitel
+        /// </summary>
+        public Adelstitel[] Titel { get; private set; }
+        
         private int maxAnzahlWahlen;
         private int maxAnzahlAmtsenthebungen;
         #endregion
@@ -1211,18 +1215,18 @@ namespace Conspiratio.Lib.Gameplay.Spielwelt
 
             #region Titel
             MaxTitelID = 10;
-            Tit = new Adelstitel[MaxTitelID];
+            Titel = new Adelstitel[MaxTitelID];
 
-            Tit[0] = new Herr(0, "Herr", "Frau", 0);
-            Tit[1] = new Buerger(1, "Bürger", "Bürgerin", 5);
-            Tit[2] = new Edelmann(2, "Edelmann", "Edelfrau", 10);
-            Tit[3] = new Ritter(3, "Ritter", "Hofdame", 20);
-            Tit[4] = new Landherr(4, "Landherr", "Landfrau", 35);
-            Tit[5] = new Freiherr(5, "Freiherr", "Freifrau", 55);
-            Tit[6] = new Baron(6, "Baron", "Baronin", 75);
-            Tit[7] = new Graf(7, "Graf", "Gräfin", 100);
-            Tit[8] = new Fuerst(8, "Fürst", "Fürstin", 125);
-            Tit[9] = new Herzog(9, "Herzog", "Herzogin", 150);
+            Titel[0] = new Herr(0, "Herr", "Frau", 0, 0);
+            Titel[1] = new Buerger(1, "Bürger", "Bürgerin", 0, 5);
+            Titel[2] = new Edelmann(2, "Edelmann", "Edelfrau", 5000, 10);
+            Titel[3] = new Ritter(3, "Ritter", "Hofdame", 15000, 20);
+            Titel[4] = new Landherr(4, "Landherr", "Landfrau", 40000, 35);
+            Titel[5] = new Freiherr(5, "Freiherr", "Freifrau", 80000, 55);
+            Titel[6] = new Baron(6, "Baron", "Baronin", 150000, 75);
+            Titel[7] = new Graf(7, "Graf", "Gräfin", 250000, 100);
+            Titel[8] = new Fuerst(8, "Fürst", "Fürstin", 350000, 125);
+            Titel[9] = new Herzog(9, "Herzog", "Herzogin", 500000, 150);
             #endregion
 
             #region Werbegeschenke anlegen
@@ -1446,7 +1450,7 @@ namespace Conspiratio.Lib.Gameplay.Spielwelt
         public int GetMinKindSlotNr() { return minKindSlotNr; }
         public int GetMaxPriv() { return maxPrivilegien; }
         public int GetMaxKredite() { return maxKrediteAnzahl; }
-        public Adelstitel GetTitelX(int x) { return Tit[x]; }
+        public Adelstitel GetTitelX(int x) { return Titel[x]; }
         public IPrivileg GetPrivX(int x) { return Privilegien[x]; }
         public Karawane GetKarawane(int x) { return Kara[x]; }
         public int GetDefaultKarawane() { return DefaultKarawane; }

--- a/Conspiratio.Lib/Gameplay/Titel/Adelstitel.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Adelstitel.cs
@@ -1,11 +1,13 @@
-﻿namespace Conspiratio.Lib.Gameplay.Titel
+﻿using Conspiratio.Lib.Gameplay.Spielwelt;
+
+namespace Conspiratio.Lib.Gameplay.Titel
 {
     public class Adelstitel
     {
         /// <summary>
         /// Rang des Titels (Reihenfolge), startet bei 0 für den ersten Titel.
         /// </summary>
-        public int ID { get; }
+        public int Id { get; }
 
         /// <summary>
         /// Männliche Bezeichnung des Titels
@@ -18,15 +20,21 @@
         public string NameWeiblich { get; }
 
         /// <summary>
+        /// Die Talermenge, die zur Verleihung dieses Titels mindestens notwendig ist.
+        /// </summary>
+        public int AbTaler { get; }
+
+        /// <summary>
         /// Hat aktuell noch keine Auswirkung. Ist wahrscheinlich für einen Ansehensbonus durch den Titel gedacht gewesen.
         /// </summary>
         public int BonusAnsehen { get; }
 
-        public Adelstitel(int id, string nameMaennlich, string nameWeiblich, int bonusAnsehen)
+        public Adelstitel(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
         {
-            ID = id;
+            Id = id;
             NameMaennlich = nameMaennlich;
             NameWeiblich = nameWeiblich;
+            AbTaler = abTaler;
             BonusAnsehen = bonusAnsehen;
         }
 
@@ -37,14 +45,18 @@
         /// <returns>Bezeichnung des Titels</returns>
         public string GetName(bool maennlich)
         {
-            if (maennlich)
-            {
-                return NameMaennlich;
-            }
-            else
-            {
-                return NameWeiblich;
-            }
+            return maennlich ? NameMaennlich : NameWeiblich;
+        }
+
+        /// <summary>
+        /// Gibt zurück, ob der übergebene Spieler berechtigt ist, den Titel zu tragen.
+        /// </summary>
+        /// <param name="dynamischeSpieldaten">Objekt mit den dynamischen Spieldaten</param>
+        /// <param name="spielerId">Id des Spielers</param>
+        /// <returns>Spieler ist berechtigt (true) oder nicht (false)</returns>
+        public virtual bool IstSpielerFuerTitelBerechtigt(DynamischeSpieldaten dynamischeSpieldaten, int spielerId)
+        {
+            return dynamischeSpieldaten.GetSpWithID(spielerId).GetTaler() >= AbTaler;
         }
     }
 }

--- a/Conspiratio.Lib/Gameplay/Titel/Baron.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Baron.cs
@@ -1,10 +1,21 @@
-﻿namespace Conspiratio.Lib.Gameplay.Titel
+﻿using Conspiratio.Lib.Gameplay.Spielwelt;
+
+namespace Conspiratio.Lib.Gameplay.Titel
 {
     public class Baron : Adelstitel
     {
-        public Baron(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Baron(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
+        }
+
+        /// <inheritdoc/>
+        public override bool IstSpielerFuerTitelBerechtigt(DynamischeSpieldaten dynamischeSpieldaten, int spielerId)
+        {
+            if (!base.IstSpielerFuerTitelBerechtigt(dynamischeSpieldaten, spielerId))
+                return false;
+
+            return dynamischeSpieldaten.GetHumWithID(spielerId).BesitztSpielerFertigesHaus("Landsitz");
         }
     }
 }

--- a/Conspiratio.Lib/Gameplay/Titel/Buerger.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Buerger.cs
@@ -2,8 +2,8 @@
 {
     public class Buerger : Adelstitel
     {
-        public Buerger(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Buerger(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
         }
     }

--- a/Conspiratio.Lib/Gameplay/Titel/Edelmann.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Edelmann.cs
@@ -2,8 +2,8 @@
 {
     public class Edelmann : Adelstitel
     {
-        public Edelmann(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Edelmann(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
         }
     }

--- a/Conspiratio.Lib/Gameplay/Titel/Freiherr.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Freiherr.cs
@@ -1,10 +1,21 @@
-﻿namespace Conspiratio.Lib.Gameplay.Titel
+﻿using Conspiratio.Lib.Gameplay.Spielwelt;
+
+namespace Conspiratio.Lib.Gameplay.Titel
 {
     public class Freiherr : Adelstitel
     {
-        public Freiherr(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Freiherr(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
+        }
+
+        /// <inheritdoc/>
+        public override bool IstSpielerFuerTitelBerechtigt(DynamischeSpieldaten dynamischeSpieldaten, int spielerId)
+        {
+            if (!base.IstSpielerFuerTitelBerechtigt(dynamischeSpieldaten, spielerId))
+                return false;
+
+            return dynamischeSpieldaten.GetHumWithID(spielerId).BesitztSpielerFertigesHaus("Villa");
         }
     }
 }

--- a/Conspiratio.Lib/Gameplay/Titel/Fuerst.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Fuerst.cs
@@ -1,10 +1,24 @@
-﻿namespace Conspiratio.Lib.Gameplay.Titel
+﻿using Conspiratio.Lib.Gameplay.Spielwelt;
+
+namespace Conspiratio.Lib.Gameplay.Titel
 {
     public class Fuerst : Adelstitel
     {
-        public Fuerst(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Fuerst(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
+        }
+
+        /// <inheritdoc/>
+        public override bool IstSpielerFuerTitelBerechtigt(DynamischeSpieldaten dynamischeSpieldaten, int spielerId)
+        {
+            if (!base.IstSpielerFuerTitelBerechtigt(dynamischeSpieldaten, spielerId))
+                return false;
+
+            if (!dynamischeSpieldaten.GetHumWithID(spielerId).BesitztSpielerFertigesHaus("Schloss"))
+                return false;
+
+            return dynamischeSpieldaten.GetHumWithID(spielerId).GetAnzahlStuetzpunkte(spielerId) >= 1;
         }
     }
 }

--- a/Conspiratio.Lib/Gameplay/Titel/Graf.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Graf.cs
@@ -1,10 +1,24 @@
-﻿namespace Conspiratio.Lib.Gameplay.Titel
+﻿using Conspiratio.Lib.Gameplay.Spielwelt;
+
+namespace Conspiratio.Lib.Gameplay.Titel
 {
     public class Graf : Adelstitel
     {
-        public Graf(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Graf(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
+        }
+
+        /// <inheritdoc/>
+        public override bool IstSpielerFuerTitelBerechtigt(DynamischeSpieldaten dynamischeSpieldaten, int spielerId)
+        {
+            if (!base.IstSpielerFuerTitelBerechtigt(dynamischeSpieldaten, spielerId))
+                return false;
+
+            if (!dynamischeSpieldaten.GetHumWithID(spielerId).BesitztSpielerFertigesHaus("Burg"))
+                return false;
+
+            return dynamischeSpieldaten.GetHumWithID(spielerId).GetAnzahlStuetzpunkte(spielerId) >= 1;
         }
     }
 }

--- a/Conspiratio.Lib/Gameplay/Titel/Herr.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Herr.cs
@@ -2,8 +2,8 @@
 {
     public class Herr : Adelstitel
     {
-        public Herr(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Herr(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
         }
     }

--- a/Conspiratio.Lib/Gameplay/Titel/Herzog.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Herzog.cs
@@ -1,10 +1,24 @@
-﻿namespace Conspiratio.Lib.Gameplay.Titel
+﻿using Conspiratio.Lib.Gameplay.Spielwelt;
+
+namespace Conspiratio.Lib.Gameplay.Titel
 {
     public class Herzog : Adelstitel
     {
-        public Herzog(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Herzog(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
+        }
+
+        /// <inheritdoc/>
+        public override bool IstSpielerFuerTitelBerechtigt(DynamischeSpieldaten dynamischeSpieldaten, int spielerId)
+        {
+            if (!base.IstSpielerFuerTitelBerechtigt(dynamischeSpieldaten, spielerId))
+                return false;
+
+            if (!dynamischeSpieldaten.GetHumWithID(spielerId).BesitztSpielerFertigesHaus("Schloss"))
+                return false;
+
+            return dynamischeSpieldaten.GetHumWithID(spielerId).GetAnzahlStuetzpunkte(spielerId) >= 2;
         }
     }
 }

--- a/Conspiratio.Lib/Gameplay/Titel/Landherr.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Landherr.cs
@@ -1,10 +1,21 @@
-﻿namespace Conspiratio.Lib.Gameplay.Titel
+﻿using Conspiratio.Lib.Gameplay.Spielwelt;
+
+namespace Conspiratio.Lib.Gameplay.Titel
 {
     public class Landherr : Adelstitel
     {
-        public Landherr(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Landherr(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
+        }
+
+        /// <inheritdoc/>
+        public override bool IstSpielerFuerTitelBerechtigt(DynamischeSpieldaten dynamischeSpieldaten, int spielerId)
+        {
+            if (!base.IstSpielerFuerTitelBerechtigt(dynamischeSpieldaten, spielerId))
+                return false;
+
+            return dynamischeSpieldaten.GetHumWithID(spielerId).BesitztSpielerFertigesHaus("Landhaus");
         }
     }
 }

--- a/Conspiratio.Lib/Gameplay/Titel/Ritter.cs
+++ b/Conspiratio.Lib/Gameplay/Titel/Ritter.cs
@@ -2,8 +2,8 @@
 {
     public class Ritter : Adelstitel
     {
-        public Ritter(int i, string mn, string wn, int bona)
-            : base(i, mn, wn, bona)
+        public Ritter(int id, string nameMaennlich, string nameWeiblich, int abTaler, int bonusAnsehen)
+            : base(id, nameMaennlich, nameWeiblich, abTaler, bonusAnsehen)
         {
         }
     }

--- a/Conspiratio.Lib/Properties/AssemblyInfo.cs
+++ b/Conspiratio.Lib/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
-[assembly: AssemblyVersion("2.1.0")]
-[assembly: AssemblyFileVersion("2.1.0")]
+[assembly: AssemblyVersion("2.1.1")]
+[assembly: AssemblyFileVersion("2.1.1")]


### PR DESCRIPTION
- Version auf 2.1.1 angehoben
- Beim Privileg "Jurist aufsuchen" wird nun ein Rechtsklick im Dialog nicht mehr als "Ja" sondern als Abbruch gewertet
- Die Vergabe von Titeln wurde neu balanciert und ist nun u.a. auch vom Wohnsitz sowie vom Besitz militärischer Stützpunkte abhängig, zusätzlich wurde die Talergrenze der höheren Titel herabgesetzt. Dafür wurde die Vergabelogik in die einzelnen Titel-Klassen ausgelagert sowie etwas aufgeräumt und optimiert