### PR TITLE
Improvement/naming rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,95 @@
+
+[*]
+charset = utf-8-bom
+end_of_line = crlf
+trim_trailing_whitespace = false
+insert_final_newline = false
+indent_style = space
+indent_size = 4
+
+# Microsoft .NET properties
+csharp_new_line_before_members_in_object_initializers = false
+csharp_preferred_modifier_order = public, override, protected, internal, file, new, virtual, abstract, private, sealed, readonly, static, extern, unsafe, volatile, async, required:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+dotnet_naming_rule.unity_serialized_field_rule.import_to_resharper = True
+dotnet_naming_rule.unity_serialized_field_rule.resharper_description = Unity serialized field
+dotnet_naming_rule.unity_serialized_field_rule.resharper_guid = 5f0fdb63-c892-4d2c-9324-15c80b22a7ef
+dotnet_naming_rule.unity_serialized_field_rule.severity = warning
+dotnet_naming_rule.unity_serialized_field_rule.style = lower_camel_case_style
+dotnet_naming_rule.unity_serialized_field_rule.symbols = unity_serialized_field_symbols
+dotnet_naming_style.lower_camel_case_style.capitalization = camel_case
+dotnet_naming_symbols.unity_serialized_field_symbols.applicable_accessibilities = *
+dotnet_naming_symbols.unity_serialized_field_symbols.applicable_kinds = 
+dotnet_naming_symbols.unity_serialized_field_symbols.resharper_applicable_kinds = unity_serialised_field
+dotnet_naming_symbols.unity_serialized_field_symbols.resharper_required_modifiers = instance
+dotnet_separate_import_directive_groups = true
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+# ReSharper properties
+resharper_accessor_owner_body = accessors_with_block_body
+resharper_align_multiline_argument = true
+resharper_align_multiline_parameter = true
+resharper_arguments_skip_single = true
+resharper_autodetect_indent_settings = true
+resharper_blank_lines_after_block_statements = 0
+resharper_blank_lines_after_control_transfer_statements = 1
+resharper_braces_for_for = required_for_multiline
+resharper_braces_for_foreach = required_for_multiline
+resharper_braces_for_ifelse = not_required
+resharper_braces_for_while = required
+resharper_braces_redundant = false
+resharper_csharp_blank_lines_around_invocable = 0
+resharper_csharp_blank_lines_around_region = 0
+resharper_csharp_blank_lines_inside_region = 0
+resharper_csharp_case_block_braces = next_line_shifted_2
+resharper_csharp_insert_final_newline = true
+resharper_csharp_keep_blank_lines_in_code = 100
+resharper_csharp_max_line_length = 640
+resharper_csharp_remove_blank_lines_near_braces_in_code = false
+resharper_csharp_remove_blank_lines_near_braces_in_declarations = false
+resharper_for_other_types = use_var_when_evident
+resharper_for_simple_types = use_explicit_type
+resharper_indent_preprocessor_region = do_not_change
+resharper_instance_members_qualify_declared_in = 
+resharper_keep_existing_declaration_block_arrangement = true
+resharper_parentheses_non_obvious_operations = none, shift, relational, bitwise_and, bitwise_exclusive_or, bitwise_inclusive_or, bitwise
+resharper_parentheses_redundancy_style = remove
+resharper_parentheses_same_type_operations = true
+resharper_place_simple_accessor_on_single_line = false
+resharper_place_simple_embedded_statement_on_same_line = false
+resharper_show_autodetect_configure_formatting_tip = false
+resharper_use_indent_from_vs = false
+resharper_wrap_object_and_collection_initializer_style = chop_always
+
+# ReSharper inspection severities
+resharper_arrange_redundant_parentheses_highlighting = hint
+resharper_arrange_this_qualifier_highlighting = hint
+resharper_arrange_type_member_modifiers_highlighting = hint
+resharper_arrange_type_modifiers_highlighting = hint
+resharper_built_in_type_reference_style_for_member_access_highlighting = hint
+resharper_built_in_type_reference_style_highlighting = hint
+resharper_comment_typo_highlighting = none
+resharper_identifier_typo_highlighting = none
+resharper_markup_attribute_typo_highlighting = none
+resharper_markup_text_typo_highlighting = none
+resharper_redundant_base_qualifier_highlighting = warning
+resharper_string_literal_typo_highlighting = none
+resharper_suggest_var_or_type_built_in_types_highlighting = hint
+resharper_web_config_module_not_resolved_highlighting = warning
+resharper_web_config_type_not_resolved_highlighting = warning
+resharper_web_config_wrong_module_highlighting = warning
+
+[*.{appxmanifest,asax,ascx,aspx,axaml,build,c,c++,cc,cginc,compute,cp,cpp,cs,cshtml,cu,cuh,cxx,dtd,fs,fsi,fsscript,fsx,fx,fxh,h,hh,hlsl,hlsli,hlslinc,hpp,hxx,inc,inl,ino,ipp,ixx,master,ml,mli,mpp,mq4,mq5,mqh,nuspec,paml,razor,resw,resx,shader,skin,tpp,usf,ush,vb,xaml,xamlx,xoml,xsd}]
+indent_style = space
+indent_size = 4
+tab_width = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog Conspiratio.Lib
 
+## 2.3.0
+
+_23.12.2023_
+
+**[DE]**
+- Mit der Auslagerung der Kartenspiel Logik in neue Klasse "Kartenspiel" begonnen
+- Bugfix von "PrivilegienAktualisieren", es setzt "Amt niederlegen" nun wieder nur dann auf true, wenn der Spieler auch ein Amt bekleidet
+
+**[EN]**
+- Started with the outsourcing of the card game logic to the new class "Kartenspiel"
+- Bugfix for "PrivilegienAktualisieren", it sets "Amt niederlegen" now correct only to true, if the player has an office
+
 ## 2.2.0
 
 _06.12.2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ _06.12.2022_
 **[DE]**
 - Die Strafe "Einen Monat Kerker" hat nun eine variable Länge, abhängig von der Schwere der Schuld. Die Auswirkung auf die Gesundheit des verurteilten Spielers ist dann entsprechend höher.
 - Methode "TestamentVollstrecken" hinzugefügt (ausgelagert aus WinForms Client)
-- Rohstoffrechte (Handelszertifikate) werden nun bei jeder Amtsverleihung sowie Kauf einer Zollburg oder eines Räuberlagers gewährt und sind nicht mehr abhängig von Talergrenzen sowie nicht mehr beschränbkt auf maximal 5.
+- Rohstoffrechte (Handelszertifikate) werden nun bei jeder Amtsverleihung sowie Kauf einer Zollburg oder eines Räuberlagers gewährt und sind nicht mehr abhängig von Talergrenzen sowie nicht mehr beschränkt auf maximal 5.
 - Bei Spielen mit nur einem aktiven Spieler erhöhen Warenverkäufe des Spielers an die Stadt am Ende der Runde nun korrekt den Lagerstand der Stadt
-- Feste benötigen die Waren nun im Lager der Stadt anstelle im Lager der Niederlassung des Spielers. Somit ist es nun überhaupt erst möglich, alle Waren für die größeren Feste zu beschaffen (sofern die Handelszertifikat dafür vorhanden sind).
+- Feste benötigen die Waren nun im Lager der Stadt anstelle im Lager der Niederlassung des Spielers. Somit ist es nun überhaupt erst möglich, alle Waren für die größeren Feste zu beschaffen (sofern die Handelszertifikate dafür vorhanden sind).
 - Die von den Einwohnern einer Stadt verbrauchten Waren am Rundenende wurden reduziert
 - Kleinere Optimierungen
 

--- a/Conspiratio.Lib/Conspiratio.Lib.csproj
+++ b/Conspiratio.Lib/Conspiratio.Lib.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Gameplay\Gebiete\Stadt.cs" />
     <Compile Include="Gameplay\Hinterzimmer\AktiveSabotagen.cs" />
     <Compile Include="Gameplay\Hinterzimmer\AktiveSpionagen.cs" />
+    <Compile Include="Gameplay\Hinterzimmer\Kartenspiel.cs" />
     <Compile Include="Gameplay\Justiz\Gerichtsverhandlung.cs" />
     <Compile Include="Gameplay\Justiz\IStrafe.cs" />
     <Compile Include="Gameplay\Justiz\Strafe.cs" />

--- a/Conspiratio.Lib/Gameplay/Hinterzimmer/Kartenspiel.cs
+++ b/Conspiratio.Lib/Gameplay/Hinterzimmer/Kartenspiel.cs
@@ -1,0 +1,36 @@
+﻿using Conspiratio.Lib.Gameplay.Spielwelt;
+
+namespace Conspiratio.Lib.Gameplay.Hinterzimmer
+{
+    public class Kartenspiel
+    {
+        public string GegnerName { get; private set; }
+        public string GegnerErSie { get; private set; }
+        public string GegnerSeinenIhren { get; private set; }
+        
+        public bool FindetKartenspielStatt => SW.Dynamisch.GetHumWithID(SW.Dynamisch.GetAktiverSpieler()).GetSpieltKartenGegenSpielerID() != 0;
+
+        public bool HatSpielerGenugTaler() => SW.Dynamisch.GetHumWithID(SW.Dynamisch.GetAktiverSpieler()).GetTaler() > SW.Statisch.GetKartenSpielenMinTaler();
+        
+        public void InitiiereKartenspielUndErmittleGegner()
+        {
+            if (SW.Dynamisch.GetGesetzX(4) > 0)
+                SW.Dynamisch.GetHumWithID(SW.Dynamisch.GetAktiverSpieler()).ErhoeheGesetzXUmEins(4);
+
+            var kiGegner = SW.Dynamisch.GetKIwithID(SW.Dynamisch.GetHumWithID(SW.Dynamisch.GetAktiverSpieler()).GetSpieltKartenGegenSpielerID());
+            
+            GegnerName = kiGegner.GetKompletterName();
+            
+            if (kiGegner.GetMaennlich())
+            {
+                GegnerErSie = "er";
+                GegnerSeinenIhren = "seinen";
+            }
+            else
+            {
+                GegnerErSie = "sie";
+                GegnerSeinenIhren = "ihren";
+            }
+        }
+    }
+}

--- a/Conspiratio.Lib/Gameplay/Spielwelt/DynamischeSpieldaten.cs
+++ b/Conspiratio.Lib/Gameplay/Spielwelt/DynamischeSpieldaten.cs
@@ -2066,7 +2066,7 @@ namespace Conspiratio.Lib.Gameplay.Spielwelt
             #endregion
 
             #region 2 - Amt niederlegen
-            GetAktHum().SetPrivilegX(2, GetAktHum().GetAmtID() == 0);  // Amt niederlegen nur möglich, wenn Amt vorhanden ist
+            GetAktHum().SetPrivilegX(2, GetAktHum().GetAmtID() != 0);  // Amt niederlegen nur möglich, wenn Amt vorhanden ist
             #endregion
 
             #region 3 - Testament machen

--- a/Conspiratio.Lib/Properties/AssemblyInfo.cs
+++ b/Conspiratio.Lib/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
-[assembly: AssemblyVersion("2.2.0")]
-[assembly: AssemblyFileVersion("2.2.0")]
+[assembly: AssemblyVersion("3.0.0")]
+[assembly: AssemblyFileVersion("3.0.0")]

--- a/Conspiratio.Lib/Properties/AssemblyInfo.cs
+++ b/Conspiratio.Lib/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
-[assembly: AssemblyVersion("3.0.0")]
-[assembly: AssemblyFileVersion("3.0.0")]
+[assembly: AssemblyVersion("2.3.0")]
+[assembly: AssemblyFileVersion("2.3.0")]


### PR DESCRIPTION
- new .editorconfig für naming guidelines
- started with the outsourcing of the card game logic to the new class "Kartenspiel"
- upgraded version to 2.3.0
- bugfix for "PrivilegienAktualisieren", it sets "Amt niederlegen" now correct only to true, if the player has an office